### PR TITLE
[FIX] Param check only on built-ins

### DIFF
--- a/benchmarks/memory_cpu_profile.py
+++ b/benchmarks/memory_cpu_profile.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Create memory and CPU profile plots.

--- a/benchmarks/memory_cpu_profile.py
+++ b/benchmarks/memory_cpu_profile.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Create memory and CPU profile plots.

--- a/check_build.py
+++ b/check_build.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Testing suite for ML-Ensemble build.

--- a/check_build.py
+++ b/check_build.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Testing suite for ML-Ensemble build.

--- a/mlens/__init__.py
+++ b/mlens/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 ML-Ensemble, a Python library for memory efficient parallelized ensemble

--- a/mlens/__init__.py
+++ b/mlens/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 ML-Ensemble, a Python library for memory efficient parallelized ensemble

--- a/mlens/config.py
+++ b/mlens/config.py
@@ -2,7 +2,7 @@
 
 :author: Sebastian Flennerhag
 :license: MIT
-:copyright: 2017
+:copyright: 2017–2018
 
 Global backend configurations.
 

--- a/mlens/config.py
+++ b/mlens/config.py
@@ -2,7 +2,7 @@
 
 :author: Sebastian Flennerhag
 :license: MIT
-:copyright: 2017–2018
+:copyright: 2017-2018
 
 Global backend configurations.
 

--- a/mlens/ensemble/__init__.py
+++ b/mlens/ensemble/__init__.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Graph handles for deep computational graphs and ready-made ensemble classes

--- a/mlens/ensemble/__init__.py
+++ b/mlens/ensemble/__init__.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Graph handles for deep computational graphs and ready-made ensemble classes

--- a/mlens/ensemble/base.py
+++ b/mlens/ensemble/base.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Base classes for ensemble layer management.

--- a/mlens/ensemble/base.py
+++ b/mlens/ensemble/base.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Base classes for ensemble layer management.

--- a/mlens/ensemble/blend.py
+++ b/mlens/ensemble/blend.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Blend Ensemble class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/blend.py
+++ b/mlens/ensemble/blend.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Blend Ensemble class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/sequential.py
+++ b/mlens/ensemble/sequential.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Sequential Ensemble class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/sequential.py
+++ b/mlens/ensemble/sequential.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Sequential Ensemble class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/subsemble.py
+++ b/mlens/ensemble/subsemble.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Subsemble class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/subsemble.py
+++ b/mlens/ensemble/subsemble.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Subsemble class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/super_learner.py
+++ b/mlens/ensemble/super_learner.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Super Learner class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/super_learner.py
+++ b/mlens/ensemble/super_learner.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Super Learner class. Fully integrable with Scikit-learn.

--- a/mlens/ensemble/tests/test_a_sklearn.py
+++ b/mlens/ensemble/tests/test_a_sklearn.py
@@ -3,6 +3,7 @@ Test Scikit-learn
 """
 import numpy as np
 from mlens.ensemble import SuperLearner, Subsemble, BlendEnsemble
+from mlens.testing.dummy import return_pickled
 try:
     from sklearn.utils.estimator_checks import check_estimator
     from sklearn.linear_model import Lasso, LinearRegression
@@ -63,6 +64,9 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
 
     def test_super_learner_f_m():
         """[SuperLearner] Test scikit-learn comp - mp | p"""
@@ -72,6 +76,11 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
+
     def test_super_learner_s_t():
         """[SuperLearner] Test scikit-learn comp - th | np"""
         ens = get_ensemble(SuperLearner, 'threading', None)
@@ -79,6 +88,11 @@ if has_sklearn:
         p = ens.predict(X)
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
+
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
 
     def test_super_learner_f_t():
         """[SuperLearner] Test scikit-learn comp - th | p"""
@@ -88,6 +102,11 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
+
     def test_subsemble_s_m():
         """[Subsemble] Test scikit-learn comp - mp | np"""
         ens = get_ensemble(Subsemble, 'multiprocessing', None)
@@ -95,6 +114,11 @@ if has_sklearn:
         p = ens.predict(X)
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
+
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
 
 
     def test_subsemble_f_m():
@@ -105,6 +129,11 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
+
     def test_subsemble_s_t():
         """[Subsemble] Test scikit-learn comp - th | np"""
         ens = get_ensemble(Subsemble, 'threading', None)
@@ -112,6 +141,11 @@ if has_sklearn:
         p = ens.predict(X)
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
+
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
 
     def test_subsemble_f_t():
         """[Subsemble] Test scikit-learn comp - th | p"""
@@ -121,6 +155,11 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
+
     def test_blend_s_m():
         """[BlendEnsemble] Test scikit-learn comp - mp | np"""
         ens = get_ensemble(BlendEnsemble, 'multiprocessing', None)
@@ -128,6 +167,10 @@ if has_sklearn:
         p = ens.predict(X)
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
+
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
 
 
     def test_blend_f_m():
@@ -138,6 +181,11 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
+
     def test_blend_s_m():
         """[BlendEnsemble] Test scikit-learn comp - th | np"""
         ens = get_ensemble(BlendEnsemble, 'threading', None)
@@ -146,6 +194,11 @@ if has_sklearn:
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
 
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
+
+
     def test_blend_f_m():
         """[BlendEnsemble] Test scikit-learn comp - th | p"""
         ens = get_ensemble(BlendEnsemble, 'threading', prep)
@@ -153,4 +206,8 @@ if has_sklearn:
         p = ens.predict(X)
         assert p.shape == y.shape
         assert p.dtype == ens.layer_1.dtype
+
+        ens = return_pickled(ens)
+        pp = ens.predict(X)
+        np.testing.assert_array_equal(p, pp)
 

--- a/mlens/estimators/__init__.py
+++ b/mlens/estimators/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 """
 from .estimators import BaseEstimator

--- a/mlens/estimators/__init__.py
+++ b/mlens/estimators/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 """
 from .estimators import BaseEstimator

--- a/mlens/estimators/estimators.py
+++ b/mlens/estimators/estimators.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Scikit-learn estimators of computational graph nodes. Estimator classes are

--- a/mlens/estimators/estimators.py
+++ b/mlens/estimators/estimators.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Scikit-learn estimators of computational graph nodes. Estimator classes are

--- a/mlens/index/__init__.py
+++ b/mlens/index/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Classes for implementing various cross-validation strategies. By default,

--- a/mlens/index/__init__.py
+++ b/mlens/index/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Classes for implementing various cross-validation strategies. By default,

--- a/mlens/index/_checks.py
+++ b/mlens/index/_checks.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Indexer checks

--- a/mlens/index/_checks.py
+++ b/mlens/index/_checks.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Indexer checks

--- a/mlens/index/base.py
+++ b/mlens/index/base.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 

--- a/mlens/index/base.py
+++ b/mlens/index/base.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 

--- a/mlens/index/blend.py
+++ b/mlens/index/blend.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Blend indexing.

--- a/mlens/index/blend.py
+++ b/mlens/index/blend.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Blend indexing.

--- a/mlens/index/fold.py
+++ b/mlens/index/fold.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Stack indexing.

--- a/mlens/index/fold.py
+++ b/mlens/index/fold.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Stack indexing.

--- a/mlens/index/subsemble.py
+++ b/mlens/index/subsemble.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Partitioning estimators

--- a/mlens/index/subsemble.py
+++ b/mlens/index/subsemble.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Partitioning estimators

--- a/mlens/metrics/__init__.py
+++ b/mlens/metrics/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Metric utilities and functions.

--- a/mlens/metrics/__init__.py
+++ b/mlens/metrics/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Metric utilities and functions.

--- a/mlens/metrics/metrics.py
+++ b/mlens/metrics/metrics.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Scoring functions.

--- a/mlens/metrics/metrics.py
+++ b/mlens/metrics/metrics.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Scoring functions.

--- a/mlens/metrics/utils.py
+++ b/mlens/metrics/utils.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Utility functions for constructing metrics

--- a/mlens/metrics/utils.py
+++ b/mlens/metrics/utils.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Utility functions for constructing metrics

--- a/mlens/model_selection/__init__.py
+++ b/mlens/model_selection/__init__.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Model selection suite for ensemble learning.

--- a/mlens/model_selection/__init__.py
+++ b/mlens/model_selection/__init__.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Model selection suite for ensemble learning.

--- a/mlens/model_selection/ensemble_transformer.py
+++ b/mlens/model_selection/ensemble_transformer.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Ensemble transformer class. Fully integrable with Scikit-learn.

--- a/mlens/model_selection/ensemble_transformer.py
+++ b/mlens/model_selection/ensemble_transformer.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Ensemble transformer class. Fully integrable with Scikit-learn.

--- a/mlens/model_selection/model_selection.py
+++ b/mlens/model_selection/model_selection.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Model selection suite for tuning and benchmarking a set of estimators.

--- a/mlens/model_selection/model_selection.py
+++ b/mlens/model_selection/model_selection.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Model selection suite for tuning and benchmarking a set of estimators.

--- a/mlens/parallel/__init__.py
+++ b/mlens/parallel/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Computational graph module for memory-neutral parallel processing of

--- a/mlens/parallel/__init__.py
+++ b/mlens/parallel/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Computational graph module for memory-neutral parallel processing of

--- a/mlens/parallel/_base_functions.py
+++ b/mlens/parallel/_base_functions.py
@@ -271,10 +271,20 @@ def check_params(lpar, rpar):
         return True
 
     # --- param check ---
+    if lpar is None:
+        return rpar is None
 
-    if isinstance(lpar, (int, float, str, bool)):
-        # Only test base parameter classes (never test complex classes)
+    if isinstance(lpar, (str, bool)):
         return lpar == rpar
+
+    if isinstance(lpar, (int, float)):
+        if np.isnan(lpar):
+            val = np.isnan(rpar)
+        elif np.isinf(lpar):
+            val = np.isinf(rpar)
+        else:
+            val = lpar == rpar
+        return val
 
     # If par is not int, float, str or bool, we don't want to fail the check
     return True

--- a/mlens/parallel/_base_functions.py
+++ b/mlens/parallel/_base_functions.py
@@ -2,7 +2,7 @@
 
 :author: Sebastian Flennerhag
 :license: MIT
-:copyright: 2017–2018
+:copyright: 2017-2018
 
 Functions for base computations
 """

--- a/mlens/parallel/backend.py
+++ b/mlens/parallel/backend.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Parallel processing backend classes. Manages memory-mapping of data, estimation

--- a/mlens/parallel/backend.py
+++ b/mlens/parallel/backend.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Parallel processing backend classes. Manages memory-mapping of data, estimation

--- a/mlens/parallel/base.py
+++ b/mlens/parallel/base.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Base classes for parallel estimation

--- a/mlens/parallel/base.py
+++ b/mlens/parallel/base.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Base classes for parallel estimation

--- a/mlens/parallel/handles.py
+++ b/mlens/parallel/handles.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Handles for mlens.parallel.

--- a/mlens/parallel/handles.py
+++ b/mlens/parallel/handles.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Handles for mlens.parallel.

--- a/mlens/parallel/layer.py
+++ b/mlens/parallel/layer.py
@@ -2,7 +2,7 @@
 
 :author: Sebastian Flennerhag
 :license: MIT
-:copyright: 2017
+:copyright: 2017–2018
 
 Layer module.
 """

--- a/mlens/parallel/layer.py
+++ b/mlens/parallel/layer.py
@@ -2,7 +2,7 @@
 
 :author: Sebastian Flennerhag
 :license: MIT
-:copyright: 2017–2018
+:copyright: 2017-2018
 
 Layer module.
 """

--- a/mlens/parallel/learner.py
+++ b/mlens/parallel/learner.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Computational graph nodes. Job generator classes spawning jobs and executing

--- a/mlens/parallel/learner.py
+++ b/mlens/parallel/learner.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Computational graph nodes. Job generator classes spawning jobs and executing

--- a/mlens/parallel/tests/test_b4_layer_push_pop.py
+++ b/mlens/parallel/tests/test_b4_layer_push_pop.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Test layer push and pop ops.

--- a/mlens/parallel/tests/test_b4_layer_push_pop.py
+++ b/mlens/parallel/tests/test_b4_layer_push_pop.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Test layer push and pop ops.

--- a/mlens/parallel/wrapper.py
+++ b/mlens/parallel/wrapper.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Estimator wrappers around base classes.

--- a/mlens/parallel/wrapper.py
+++ b/mlens/parallel/wrapper.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Estimator wrappers around base classes.

--- a/mlens/preprocessing/__init__.py
+++ b/mlens/preprocessing/__init__.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Auxiliary transformers to support computational graphs.

--- a/mlens/preprocessing/__init__.py
+++ b/mlens/preprocessing/__init__.py
@@ -1,7 +1,7 @@
 """ML-Ensemble
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Auxiliary transformers to support computational graphs.

--- a/mlens/preprocessing/preprocess.py
+++ b/mlens/preprocessing/preprocess.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 """
 

--- a/mlens/preprocessing/preprocess.py
+++ b/mlens/preprocessing/preprocess.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 """
 

--- a/mlens/testing/__init__.py
+++ b/mlens/testing/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Testing objects

--- a/mlens/testing/__init__.py
+++ b/mlens/testing/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Testing objects

--- a/mlens/testing/dummy.py
+++ b/mlens/testing/dummy.py
@@ -14,16 +14,16 @@ import shutil
 import warnings
 
 from abc import abstractmethod
-
 import numpy as np
 
+from ..utils.utils import pickle_save, pickle_load
 from ..utils.dummy import OLS, LogisticRegression, Scale
 from ..externals.sklearn.base import clone
 from ..index import INDEXERS
 from ..ensemble.base import Sequential
+from ..estimators import LayerEnsemble
 from ..parallel import (
     ParallelProcessing, Learner, Transformer, Layer, make_group, Pipeline)
-from ..estimators import LayerEnsemble
 
 ##############################################################################
 PREPROCESSING = {'no': [], 'sc': [('scale', Scale())]}
@@ -618,3 +618,12 @@ def run_layer(job, layer, X, y, F, wf=None):
 
         assert P.__class__.__name__ == 'ndarray'
         assert w[0].__class__.__name__ == 'ndarray'
+
+
+def return_pickled(model):
+    """Pickle a model and return the loaded model"""
+    loc = str(np.random.randint(0, 1000000))
+    pickle_save(model, loc)
+    model = pickle_load(loc)
+    os.remove(loc + '.pkl')
+    return model

--- a/mlens/testing/dummy.py
+++ b/mlens/testing/dummy.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Helpers to generate test cases

--- a/mlens/testing/dummy.py
+++ b/mlens/testing/dummy.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Helpers to generate test cases

--- a/mlens/utils/__init__.py
+++ b/mlens/utils/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 """
 

--- a/mlens/utils/__init__.py
+++ b/mlens/utils/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 """
 

--- a/mlens/utils/checks.py
+++ b/mlens/utils/checks.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Controls that an estimator was built as expected.

--- a/mlens/utils/checks.py
+++ b/mlens/utils/checks.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Controls that an estimator was built as expected.

--- a/mlens/utils/dummy.py
+++ b/mlens/utils/dummy.py
@@ -88,7 +88,6 @@ class OLS(BaseEstimator):
         return np.dot(X, self.coef_.T)
 
 
-
 class LogisticRegression(OLS):
 
     """No frill Logistic Regressor w. one-vs-rest estimation of P(label).

--- a/mlens/utils/dummy.py
+++ b/mlens/utils/dummy.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Collection of dummy estimator classes, Mixins to build transparent layers for

--- a/mlens/utils/dummy.py
+++ b/mlens/utils/dummy.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Collection of dummy estimator classes, Mixins to build transparent layers for

--- a/mlens/utils/formatting.py
+++ b/mlens/utils/formatting.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Formatting of instance lists.

--- a/mlens/utils/formatting.py
+++ b/mlens/utils/formatting.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Formatting of instance lists.

--- a/mlens/utils/id_train.py
+++ b/mlens/utils/id_train.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Class for identifying a training set after an estimator has been fitted. Used

--- a/mlens/utils/id_train.py
+++ b/mlens/utils/id_train.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Class for identifying a training set after an estimator has been fitted. Used

--- a/mlens/utils/tests/test_utils.py
+++ b/mlens/utils/tests/test_utils.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 """
 

--- a/mlens/utils/tests/test_utils.py
+++ b/mlens/utils/tests/test_utils.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 """
 

--- a/mlens/utils/utils.py
+++ b/mlens/utils/utils.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 """
 

--- a/mlens/utils/utils.py
+++ b/mlens/utils/utils.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 """
 

--- a/mlens/utils/validation.py
+++ b/mlens/utils/validation.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 Input validation module. Builds on Scikit-learns ``validation`` module, but

--- a/mlens/utils/validation.py
+++ b/mlens/utils/validation.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 Input validation module. Builds on Scikit-learns ``validation`` module, but

--- a/mlens/visualization/__init__.py
+++ b/mlens/visualization/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 """
 

--- a/mlens/visualization/__init__.py
+++ b/mlens/visualization/__init__.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 """
 

--- a/mlens/visualization/correlations.py
+++ b/mlens/visualization/correlations.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Correlation plots.

--- a/mlens/visualization/correlations.py
+++ b/mlens/visualization/correlations.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Correlation plots.

--- a/mlens/visualization/var_analysis.py
+++ b/mlens/visualization/var_analysis.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :licence: MIT
 
 Explained variance plots.

--- a/mlens/visualization/var_analysis.py
+++ b/mlens/visualization/var_analysis.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :licence: MIT
 
 Explained variance plots.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017–2018
+:copyright: 2017-2018
 :license: MIT
 
 ML-Ensemble - a library for Ensemble Learning

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """ML-ENSEMBLE
 
 :author: Sebastian Flennerhag
-:copyright: 2017
+:copyright: 2017–2018
 :license: MIT
 
 ML-Ensemble - a library for Ensemble Learning


### PR DESCRIPTION
Fixes ``param_check`` to only consider ``int``, ``float``, ``None``, ``bool`` and ``str``parameter classes. ``int`` and ``float`` also has special tests for ``nan`` and ``inf``. Commit also includes tests for pickling fitted ensembles with scikit-learn estimators.
Copyrights are updated to ``2017–2018``.