### PR TITLE
Convervative ndarray casting

### DIFF
--- a/mlens/parallel/_base_functions.py
+++ b/mlens/parallel/_base_functions.py
@@ -170,16 +170,16 @@ def slice_array(x, y, idx, r=0):
             y = y[slice(idx[0] - r, idx[1] - r)] if y is not None else y
 
     # Cast as ndarray to avoid passing memmaps to estimators
-    if y is not None:
+    if y is not None and isinstance(y, np.memmap):
         y = y.view(type=np.ndarray)
-    if not issparse(x):
+    if not issparse(x) and isinstance(x, np.memmap):
         x = x.view(type=np.ndarray)
 
     return x, y
 
 
 def assign_predictions(pred, p, tei, col, n):
-    """Assign predictions to memmaped prediction array."""
+    """Assign predictions to prediction array."""
     if tei == 'all':
         tei = None
 

--- a/mlens/parallel/_base_functions.py
+++ b/mlens/parallel/_base_functions.py
@@ -139,6 +139,15 @@ def set_output_columns(
         obj.output_columns = col_dict
 
 
+def _safe_slice(array, idx):
+    """Slice an array safely along the row axis"""
+    if array is None:
+        return array
+    elif hasattr(array, 'iloc'):
+        return array.iloc[idx]
+    return array[idx]
+
+
 def slice_array(x, y, idx, r=0):
     """Build training array index and slice data."""
     if idx == 'all':
@@ -153,8 +162,8 @@ def slice_array(x, y, idx, r=0):
                 # of the slice in question to be made
                 simple_slice = False
                 idx = np.hstack([np.arange(t0 - r, t1 - r) for t0, t1 in idx])
-                x = x[idx]
-                y = y[idx] if y is not None else y
+                x = _safe_slice(x, idx)
+                y = _safe_slice(y, idx)
             else:
                 # The tuple is of the form ((a, b),) and can be made
                 # into a simple (a, b) tuple for which basic slicing applies


### PR DESCRIPTION
Avoid casting to ``ndarray`` if we don't know that the underlying data needs it (i.e. is an ``mmap`` instance). 