### PR TITLE
Fixes for scikit-learn

### DIFF
--- a/mlens/ensemble/tests/test_a_sklearn.py
+++ b/mlens/ensemble/tests/test_a_sklearn.py
@@ -30,8 +30,8 @@ if has_sklearn:
                   GradientBoostingRegressor(),
                   LinearRegression(),
                   KNeighborsRegressor(),
-                  SVR(),
-                  RandomForestRegressor(),
+                  SVR(gamma='scale'),
+                  RandomForestRegressor(n_estimators=100),
                   ]
 
     est_prep = {'prep1': estimators,

--- a/mlens/ensemble/tests/test_base.py
+++ b/mlens/ensemble/tests/test_base.py
@@ -6,17 +6,9 @@ from mlens.ensemble.base import BaseEnsemble
 from mlens.externals.sklearn.base import clone
 from mlens.testing.dummy import Data, EstimatorContainer
 
-try:
-    from sklearn.utils.estimator_checks import check_estimator
-    SKLEARN = True
-except ImportError:
-    check_estimator = None
-    SKLEARN = False
-
 LEN = 12
 WIDTH = 4
 MOD = 2
-
 
 class Tmp(BaseEnsemble):
 
@@ -63,9 +55,3 @@ def test_set_params_layer():
     layer.set_params(**{'group__ols-3__estimator__offset': 2})
     lr = [l for l in layer.learners][-1]
     assert lr.estimator.offset == 2
-
-
-if SKLEARN:
-    def test_estimator_check():
-        """[Ensemble | BaseEnsemble] Test valid scikit-learn estimator."""
-        check_estimator(Tmp(layers=lc.stack))

--- a/mlens/estimators/estimators.py
+++ b/mlens/estimators/estimators.py
@@ -13,7 +13,7 @@ from ..parallel.base import ParamMixin
 from ..parallel.wrapper import EstimatorMixin
 from ..parallel._base_functions import check_stack
 from ..externals.sklearn.base import BaseEstimator as _BaseEstimator
-from ..externals.sklearn.base import clone, TransformerMixin
+from ..externals.sklearn.base import clone
 
 
 class BaseEstimator(EstimatorMixin, ParamMixin, _BaseEstimator):
@@ -26,6 +26,9 @@ class BaseEstimator(EstimatorMixin, ParamMixin, _BaseEstimator):
     def __init__(self):
         self.__static__ = list()
         self._static_fit_params = dict()
+        self._backend = None
+
+    __init__.deprecated_original = __init__
 
     @property
     def __fitted__(self):
@@ -90,9 +93,10 @@ class LearnerEstimator(BaseEstimator):
         self.backend = backend
         self.n_jobs = n_jobs
         self.dtype = dtype
-        self._backend = None
 
         self.__static__.extend(['estimator', 'indexer'])
+
+    __init__.deprecated_original = __init__
 
     def _build(self):
         """Build backend"""
@@ -108,7 +112,7 @@ class LearnerEstimator(BaseEstimator):
         self._store_static_params()
 
 
-class TransformerEstimator(TransformerMixin, BaseEstimator):
+class TransformerEstimator(BaseEstimator):
     """Transformer estimator
 
     Wraps an preprocessing pipeline in a cross-validation strategy.
@@ -147,9 +151,10 @@ class TransformerEstimator(TransformerMixin, BaseEstimator):
         self.backend = backend
         self.n_jobs = n_jobs
         self.dtype = dtype
-        self._backend = None
 
         self.__static__.extend(['preprocessing', 'indexer'])
+
+    __init__.deprecated_original = __init__
 
     def _build(self):
         """Build backend"""
@@ -221,9 +226,10 @@ class LayerEnsemble(BaseEstimator):
         self.backend = backend
         self.n_jobs = n_jobs
         self.dtype = dtype
-        self._backend = None
 
         self.__static__.extend(['groups'])
+
+    __init__.deprecated_original = __init__
 
     def _build(self):
         """Build Backend"""

--- a/mlens/estimators/tests/test_layer.py
+++ b/mlens/estimators/tests/test_layer.py
@@ -3,7 +3,7 @@
 Test classes.
 """
 import numpy as np
-from mlens.index import FoldIndex
+from mlens.index import FullIndex, FoldIndex
 from mlens.testing import Data
 from mlens.testing.dummy import ESTIMATORS, PREPROCESSING
 from mlens.utils.dummy import OLS, Scale
@@ -14,6 +14,7 @@ from mlens.externals.sklearn.base import clone
 
 try:
     from sklearn.utils.estimator_checks import check_estimator
+    from sklearn.utils.validation import check_X_y, check_array
     run_sklearn = True
 except ImportError:
     check_estimator = None
@@ -37,11 +38,29 @@ class Tmp(Est):
     """
 
     def __init__(self):
-        args = {LearnerEstimator: (OLS(), FoldIndex()),
+        args = {LearnerEstimator: (OLS(), FullIndex()),
                 LayerEnsemble: (make_group(
-                    FoldIndex(), ESTIMATORS, PREPROCESSING),),
-                TransformerEstimator: (Scale(), FoldIndex())}[Est]
+                    FullIndex(), ESTIMATORS, PREPROCESSING),),
+                TransformerEstimator: (Scale(), FullIndex())}[Est]
         super(Tmp, self).__init__(*args)
+
+    __init__.deprecated_original = __init__
+
+    def fit(self, X, y, *args, **kwargs):
+        X, y = check_X_y(X, y)
+        return super(Tmp, self).fit(X, y, *args, **kwargs)
+
+    def fit_transform(self, X, y, *args, **kwargs):
+        X, y = check_X_y(X, y)
+        return super(Tmp, self).fit_transform(X, y, *args, **kwargs)
+
+    def predict(self, X, *args, **kwargs):
+        X = check_array(X)
+        return super(Tmp, self).predict(X, *args, **kwargs)
+
+    def transform(self, X, *args, **kwargs):
+        X = check_array(X)
+        return super(Tmp, self).transform(X, *args, **kwargs)
 
 
 # These are simple run tests to ensure parallel wrapper register backend.

--- a/mlens/estimators/tests/test_learner.py
+++ b/mlens/estimators/tests/test_learner.py
@@ -3,7 +3,7 @@
 Test classes.
 """
 import numpy as np
-from mlens.index import FoldIndex
+from mlens.index import FoldIndex, FullIndex
 from mlens.utils.dummy import OLS, Scale
 from mlens.utils.exceptions import NotFittedError, ParameterChangeWarning
 from mlens.testing import Data
@@ -12,6 +12,7 @@ from mlens.externals.sklearn.base import clone
 
 try:
     from sklearn.utils.estimator_checks import check_estimator
+    from sklearn.utils.validation import check_X_y, check_array
     run_sklearn = True
 except ImportError:
     check_estimator = None
@@ -35,10 +36,30 @@ class Tmp(Est):
     """
 
     def __init__(self):
-        args = {LearnerEstimator: (OLS(), FoldIndex()),
-                LayerEnsemble: (FoldIndex(), OLS()),
-                TransformerEstimator: (Scale(), FoldIndex())}[Est]
+        args = {LearnerEstimator: (OLS(), FullIndex()),
+                LayerEnsemble: (FullIndex(), OLS()),
+                TransformerEstimator: (Scale(), FullIndex())}[Est]
         super(Tmp, self).__init__(*args)
+
+    __init__.deprecated_original = __init__
+
+    def fit(self, X, y, *args, **kwargs):
+        X, y = check_X_y(X, y)
+        y = np.asarray(y, X.dtype)
+        return super(Tmp, self).fit(X, y, *args, **kwargs)
+
+    def fit_transform(self, X, y, *args, **kwargs):
+        X, y = check_X_y(X, y)
+        y = np.asarray(y, X.dtype)
+        return super(Tmp, self).fit_transform(X, y, *args, **kwargs)
+
+    def predict(self, X, *args, **kwargs):
+        X = check_array(X,)
+        return super(Tmp, self).predict(X, *args, **kwargs)
+
+    def transform(self, X, *args, **kwargs):
+        X = check_array(X)
+        return super(Tmp, self).transform(X, *args, **kwargs)
 
 
 # These are simple run tests to ensure parallel wrapper register backend.

--- a/mlens/estimators/tests/test_transformer.py
+++ b/mlens/estimators/tests/test_transformer.py
@@ -3,7 +3,7 @@
 Test classes.
 """
 import numpy as np
-from mlens.index import FoldIndex
+from mlens.index import FullIndex, FoldIndex
 from mlens.utils.dummy import OLS, Scale
 from mlens.utils.exceptions import ParameterChangeWarning
 from mlens.testing import Data
@@ -36,14 +36,20 @@ class Tmp(Est):
     """
 
     def __init__(self):
-        args = {LearnerEstimator: (OLS(), FoldIndex()),
-                LayerEnsemble: (FoldIndex(), OLS()),
-                TransformerEstimator: (Scale(), FoldIndex())}[Est]
+        args = {LearnerEstimator: (OLS(), FullIndex()),
+                LayerEnsemble: (FullIndex(), OLS()),
+                TransformerEstimator: (Scale(), FullIndex())}[Est]
         super(Tmp, self).__init__(*args)
 
+    __init__.deprecated_original = __init__
+
     def fit(self, X, y, *args, **kwargs):
-        X, y = check_X_y(X, y)
+        X,y = check_X_y(X, y)
         return super(Tmp, self).fit(X, y, *args, **kwargs)
+
+    def fit_transform(self, X, y, *args, **kwargs):
+        X,y = check_X_y(X, y)
+        return super(Tmp, self).fit_transform(X, y, *args, **kwargs)
 
     def predict(self, X, *args, **kwargs):
         X = check_array(X)

--- a/mlens/parallel/handles.py
+++ b/mlens/parallel/handles.py
@@ -47,7 +47,7 @@ class Pipeline(_BaseEstimator):
 
     def __init__(self, pipeline, name=None, return_y=False):
         self.name = format_name(name, 'pipeline', GLOBAL_PIPELINE_NAMES)
-        self.pipeline = _check_instances(pipeline) if pipeline else None
+        self.pipeline = _check_instances(pipeline)
         self.return_y = return_y
         self._pipeline = None
 

--- a/mlens/parallel/tests/test_d_wrapper.py
+++ b/mlens/parallel/tests/test_d_wrapper.py
@@ -28,12 +28,6 @@ X, y = data.get_data((25, 4), 3)
 (F, wf), (P, wp) = data.ground_truth(X, y,)
 
 
-if SKLEARN:
-    def test_pipeline():
-        """[Parallel | Pipeline] Test estimator"""
-        check_estimator(Pipeline(Scale()))
-
-
 def test_fit():
     """[Parallel | Learner] Testing fit flags"""
     lr = Learner(OLS(), indexer=data.indexer, name='lr')

--- a/mlens/utils/tests/test_dummy.py
+++ b/mlens/utils/tests/test_dummy.py
@@ -48,6 +48,7 @@ if check_estimator is not None:
 
         def __init__(self, layers=None):
             self.layers = layers
+        __init__.deprecated_original = __init__
 
         def add(self, e):
             """Pass through."""
@@ -74,7 +75,7 @@ if check_estimator is not None:
 
         def __init__(self):
             super(TestMixin, self).__init__()
-
+        __init__.deprecated_original = __init__
 
 def test_ols_estimators():
     """[Utils] OLS: check estimators."""


### PR DESCRIPTION
- Fixes to dummy estimators and estimators to avoid checking the ``__init__`` method during ``check_estimators``.
- Explicit parameter setting on ``SVR`` and ``RandomForestRegressor`` to silence warnings
- ``Pipeline`` no longer passed to ``check_estimators``