### PR TITLE
Make check_build run through.

### DIFF
--- a/mlens/externals/sklearn/type_of_target.py
+++ b/mlens/externals/sklearn/type_of_target.py
@@ -7,7 +7,7 @@ Imports from the utils.multiclass module of Scikit-learn.
 # License: BSD 3 clause
 
 from __future__ import division
-from collections import Sequence
+from collections.abc import Sequence
 
 
 from scipy.sparse import issparse

--- a/mlens/index/base.py
+++ b/mlens/index/base.py
@@ -80,7 +80,7 @@ def partition(n, p):
     >>> _partition(8, 3)
     array([3, 3, 2])
     """
-    sizes = (n // p) * np.ones(p, dtype=np.int)
+    sizes = (n // p) * np.ones(p, dtype=np.int32)
     sizes[:n % p] += 1
     return sizes
 

--- a/mlens/testing/dummy.py
+++ b/mlens/testing/dummy.py
@@ -356,7 +356,7 @@ class Data(object):
         t.sort()
 
         weights = []
-        F = np.zeros((len(t), n_ests * subsets * labels), dtype=np.float)
+        F = np.zeros((len(t), n_ests * subsets * labels), dtype=np.float32)
 
         col_id = {}
         col_ass = 0
@@ -417,7 +417,7 @@ class Data(object):
             indexer = self.indexer
             indexer.fit(X)
 
-        P = np.zeros((X.shape[0], n_ests * subsets * labels), dtype=np.float)
+        P = np.zeros((X.shape[0], n_ests * subsets * labels), dtype=np.float32)
 
         weights = list()
         col_id = {}

--- a/mlens/visualization/var_analysis.py
+++ b/mlens/visualization/var_analysis.py
@@ -79,7 +79,7 @@ def pca_comp_plot(X, y=None, figsize=(10, 8),
 
     for dim, frame in [(2, 221), (3, 223)]:
 
-        if dim is 3:
+        if dim == 3:
             # Need to specify projection
             subplot_kwarg = {'projection': '3d'}
 
@@ -94,7 +94,7 @@ def pca_comp_plot(X, y=None, figsize=(10, 8),
             ax[-1].set_title('%s kernel, %i dims' % (kernel, dim))
 
             # Whiten background if dim is 3
-            if dim is 3:
+            if dim == 3:
                 ax[-1].set_facecolor((1, 1, 1))
 
     if show:


### PR DESCRIPTION
Prior to this change `check_build.py` does not run through without restricting Python to an old (<3.7) version. With these changes, `check_build.py` runs through without crashes - albeit some tests are still failing.