### PR TITLE
Updating for python3.12 and numpy 1.20+

### DIFF
--- a/mlens/externals/sklearn/type_of_target.py
+++ b/mlens/externals/sklearn/type_of_target.py
@@ -7,7 +7,7 @@ Imports from the utils.multiclass module of Scikit-learn.
 # License: BSD 3 clause
 
 from __future__ import division
-from collections import Sequence
+from collections.abc import Sequence
 
 
 from scipy.sparse import issparse

--- a/mlens/index/base.py
+++ b/mlens/index/base.py
@@ -80,7 +80,7 @@ def partition(n, p):
     >>> _partition(8, 3)
     array([3, 3, 2])
     """
-    sizes = (n // p) * np.ones(p, dtype=np.int)
+    sizes = (n // p) * np.ones(p, dtype=int)
     sizes[:n % p] += 1
     return sizes
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ ML-Ensemble - a library for Ensemble Learning
 """
 
 from setuptools import setup, find_packages
-import mlens
+# import mlens
 
-VERSION = mlens.__version__
+VERSION = '0.3.0'
 
 setup(name='mlens',
       version=VERSION,


### PR DESCRIPTION
Implemented a couple of really minor changes to avoid deprecation errors to make the package work in numpy 1.20 and above along with python 3.12